### PR TITLE
Insert parentheses into arrays of arrays

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,9 +9,13 @@ module.exports = function sqlTag(queryParts, ...values) {
 	}, ``)
 }
 
-const smarterEscape = value => {
+const smarterEscape = (value, addParensToArrays) => {
 	if (Array.isArray(value)) {
-		return value.map(element => smarterEscape(element)).join(`, `)
+		let result = value.map(element => smarterEscape(element, true)).join(`, `)
+		if (addParensToArrays) {
+			result = `(` + result + `)`
+		}
+		return result
 	} else if (isObject(value)) {
 		return escape(JSON.stringify(value))
 	}

--- a/readme.md
+++ b/readme.md
@@ -71,6 +71,13 @@ const arrayQuery = sql`WHERE name IN(${[ `Alice`, userInput ]})`
 arrayQuery // => "WHERE name IN('Alice', 'Robert\\'); DROP TABLE Students;--')"
 ```
 
+```js
+const twoDimensionalArray = [[`a`, 1], [`b`, 2], [`c`, 3]]
+const twoDimensionalQuery = sql`INSERT INTO tablez (letter, number) VALUES ${twoDimensionalArray}`
+
+twoDimensionalQuery // => `INSERT INTO tablez (letter, number) VALUES ('a', 1), ('b', 2), ('c', 3)`
+```
+
 # License
 
 [WTFPL](http://wtfpl2.com/)


### PR DESCRIPTION
Another avenue-of-discussion PR...

I'd like to escape 2d arrays for use in `VALUES` or `IN`:

```js
  const my_2d_array = [
  	[1, 2, 3],
  	[4, 5, 6],
  ]
  
sql`INSERT INTO x (a, b, c) VALUES ${ my_2d_array }`
// before => `INSERT INTO x (a, b, c) VALUES 1, 2, 3, 4, 5, 6` 
// after => `INSERT INTO x (a, b, c) VALUES (1, 2, 3), (4, 5, 6)`
```