### PR TITLE
Use GH actions for testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,30 @@
+name: Node.js Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [6.x, 20.x]
+
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+        
+    - name: Install dependencies
+      run: npm ci
+      
+    - name: Run tests
+      run: npm test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,9 @@ name: Node.js Tests
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
 
 jobs:
   test:
@@ -23,7 +23,12 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
         
-    - name: Install dependencies
+    - name: Install dependencies (Node 6)
+      if: matrix.node-version == '6.x'
+      run: npm install
+      
+    - name: Install dependencies (Node 20)
+      if: matrix.node-version == '20.x'
       run: npm ci
       
     - name: Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,35 +1,20 @@
 name: Node.js Tests
-
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
-
+    branches: [master]
 jobs:
   test:
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
         node-version: [6.x, 20.x]
-
     steps:
     - uses: actions/checkout@v4
-    
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+    - uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
-        cache: 'npm'
-        
-    - name: Install dependencies (Node 6)
-      if: matrix.node-version == '6.x'
-      run: npm install
-      
-    - name: Install dependencies (Node 20)
-      if: matrix.node-version == '20.x'
-      run: npm ci
-      
-    - name: Run tests
-      run: npm test
+        cache: npm
+    - run: ${{ matrix.node-version == '6.x' && 'npm install' || 'npm ci' }}
+    - run: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: node_js
-node_js:
-  - "6"


### PR DESCRIPTION
Sorry for all the commits.  I was testing in this branch.

The node v20 test runs in ~5 seconds.  The node v6 test runs in ~150 seconds.
The node v20 test is able to take advantage of `npm ci`.